### PR TITLE
Add feature: Choose preferred scheme name.

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -9,6 +9,13 @@ class Admin_Color_Schemer_Plugin {
 
 	private $colors;
 
+	/**
+	 * The data needed for the input text form.
+	 *
+	 * @var array
+	 */
+	private $scheme_name_input;
+
 	protected function __construct() {
 		self::$instance = $this;
 		$this->base = dirname( dirname( __FILE__ ) );
@@ -26,6 +33,12 @@ class Admin_Color_Schemer_Plugin {
 	public function init() {
 		// Initialize translations
 		load_plugin_textdomain( 'admin-color-schemer', false, basename( dirname( dirname( __FILE__ ) ) ) . '/languages' );
+
+		// Set up the label name for the scheme name input form
+		$this->scheme_name_input = array(
+			'label' => __( 'Your Scheme name', 'admin-color-schemer' ),
+			'attribute'    => 'scheme_name',
+		);
 
 		// Set up color arrays - need translations
 		$this->colors['basic'] = array(
@@ -159,6 +172,15 @@ class Admin_Color_Schemer_Plugin {
 		} else {
 			return new Admin_Color_Schemer_Scheme();
 		}
+	}
+
+	/**
+	 * Gets the input data necessary for the text input form.
+	 *
+	 * @return mixed|array
+	 */
+	public function get_scheme_input() {
+		return $this->scheme_name_input;
 	}
 
 	public function get_colors( $set = null ) {
@@ -319,6 +341,13 @@ class Admin_Color_Schemer_Plugin {
 
 			echo json_encode( $response );
 			die();
+		}
+
+		//add the scheme name to the settings array
+		$scheme->name = $_post[$this->scheme_name_input['attribute']];
+
+		if ( empty ( $scheme->name) ) {
+			$scheme->name = 'Custom';
 		}
 
 		$this->set_option( 'schemes', array( $scheme->id => $scheme->to_array() ) );

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -5,11 +5,18 @@ defined( 'WPINC' ) or die;
 	<h2><?php echo esc_html( $GLOBALS['title'] ); ?></h2>
 
 	<form method="post" action="<?php echo admin_url( 'admin-post.php' ); ?>" class="color-schemer-pickers postbox">
+
 		<input type="hidden" name="action" value="admin-color-schemer-save" />
-		<?php wp_nonce_field( self::NONCE ); ?>
+		<?php
+		wp_nonce_field( self::NONCE );
+		$admin_schemer = Admin_Color_Schemer_Plugin::get_instance();
+		$scheme_label = $admin_schemer->get_scheme_input(); ?>
 		<table class="form-table">
+			<tr valign="top">
+				<th scope="row"><label for="<?php echo esc_attr( $scheme_label['attribute'] ); ?>"><?php echo esc_html( $scheme_label['label'] ); ?></label></th>
+				<td><input id="<?php echo esc_attr( $scheme_label['attribute'] ); ?>" name="<?php echo esc_attr( $scheme_label['attribute'] ); ?>" type="text" value="<?php echo esc_attr( $scheme->name ) ?>"></td>
+			</tr>
 			<?php
-			$admin_schemer = Admin_Color_Schemer_Plugin::get_instance();
 			$loops = $admin_schemer->get_colors( 'basic' );
 			foreach ( $loops as $handle => $nicename ): ?>
 


### PR DESCRIPTION
Hi @helen,

Could you use this PR that aims to add the feature requested in https://github.com/helen/admin-color-schemer/issues/16 ?

I'm not sure if my approach is intuitive enough to the end user, so it would be great to read some feedback.

So this is what the functionality looks like now: 

**When no name is provided the scheme name defaults to Custom**

![Alt Text](https://i.imgur.com/Jx2dXGK.gif)

**Example of adding a name to the custom scheme.**

![Alt Text](https://i.imgur.com/FpGOu5E.gif)

Maybe outputting an error if no scheme name is provided would be a better approach, which would be also related to issue https://github.com/helen/admin-color-schemer/issues/7

Thank you!