### PR TITLE
Increased version number after updating phpsass library to fix PHP 7 bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,8 @@ This means that your uploads folder requires credentials in order to save the th
 
 ## Changelog ##
 
+### 1.1 ###
+* Updated phpsass library to fix PHP 7 bug
+
 ### 1.0 ###
 * Initial release

--- a/admin-color-schemer.php
+++ b/admin-color-schemer.php
@@ -3,7 +3,7 @@
 Plugin Name: Admin Color Schemer
 Plugin URI: http://wordpress.org/plugins/admin-color-schemer/
 Description: Create your own admin color schemes, right in the WordPress admin.
-Version: 1.0
+Version: 1.1
 Author: WordPress Core Team
 Author URI: http://wordpress.org/
 Text Domain: admin-color-schemer


### PR DESCRIPTION
WP.org still has version 1.0 with PHP 7.x compatibility issues that were fixed in 2018. Just doing my part to hopefully push this key compatibility issue through to be available as the current official version available on WP.org and elsewhere (version number wasn't bumped when that change was made & it really should've been; better late than never!)