### PR TITLE
Ensure a #colors-css link element exists to hot reload CSS into

### DIFF
--- a/js/admin-color-schemer.js
+++ b/js/admin-color-schemer.js
@@ -24,6 +24,7 @@
 				if ( typeof r.errors != 'undefined' ) {
 					$('h2').after( '<div class="error"><p>' + r.message + '</p></div>' );
 				} else if ( typeof r.uri != 'undefined' ) {
+					// Default admin color scheme doesn't have a #colors-css link to hot load into so let's make one if we need to
 					if( ! $('#colors-css').length ) {
 						$('head').append("<link rel='stylesheet' id='colors-css' href='' media='all' />");
 					}

--- a/js/admin-color-schemer.js
+++ b/js/admin-color-schemer.js
@@ -24,6 +24,10 @@
 				if ( typeof r.errors != 'undefined' ) {
 					$('h2').after( '<div class="error"><p>' + r.message + '</p></div>' );
 				} else if ( typeof r.uri != 'undefined' ) {
+					if( ! $('#colors-css').length ) {
+						$('head').append("<link rel='stylesheet' id='colors-css' href='' media='all' />");
+					}
+
 					$('#colors-css').attr('href', r.uri);
 					$('h2').after( '<div class="update-nag">' + r.message + '</div>' );
 				}


### PR DESCRIPTION
This makes it so that custom schemes can be previewed while using the default color scheme. Fixes #29 